### PR TITLE
Improve block level locks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "gutenberg-collaborative-editing",
       "version": "0.1.0",
+      "dependencies": {
+        "@types/lodash": "^4.17.20",
+        "lodash": "^4.17.21"
+      },
       "devDependencies": {
         "@types/jest": "^29.5.12",
         "@types/react": "^18.3.3",
@@ -5996,6 +6000,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
+      "license": "MIT"
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -19599,7 +19609,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
     "lint-staged": "^16.1.6",
     "ts-jest": "^29.2.3",
     "tsconfig-paths-webpack-plugin": "^4.2.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "@types/lodash": "^4.17.20"
+  },
+  "dependencies": {
+    "lodash": "^4.17.21"
   }
 }

--- a/src/CollaborativeEditing.tsx
+++ b/src/CollaborativeEditing.tsx
@@ -12,6 +12,7 @@ export const CollaborativeEditing = () => {
 		currentUserId,
 		cursorState,
 		collaborationMode,
+		blocks,
 		state,
 		syncAwareness,
 	} = useDataManager();
@@ -19,7 +20,7 @@ export const CollaborativeEditing = () => {
 
 	useCSSClassManager( collaborationMode, activeUsers, isLockHolder );
 	useGutenbergEditorControls( collaborationMode, isLockHolder );
-	useBlockLocking( cursorState, otherActiveUsers );
+	useBlockLocking( cursorState, otherActiveUsers, blocks );
 
 	useEffect( () => {
 		if ( collaborationMode === 'BLOCK-LEVEL-LOCKS' ) {

--- a/src/CollaborativeEditing.tsx
+++ b/src/CollaborativeEditing.tsx
@@ -8,13 +8,18 @@ import { useGutenbergEditorControls } from '@/hooks/useGutenbergEditorControls';
 import { useBlockLocking } from './hooks/useBlockLocking';
 
 export const CollaborativeEditing = () => {
-	const { currentUserId, collaborationMode, state, syncAwareness } =
-		useDataManager();
+	const {
+		currentUserId,
+		cursorState,
+		collaborationMode,
+		state,
+		syncAwareness,
+	} = useDataManager();
 	const { isLockHolder, activeUsers, otherActiveUsers } = state;
 
 	useCSSClassManager( collaborationMode, activeUsers, isLockHolder );
 	useGutenbergEditorControls( collaborationMode, isLockHolder );
-	useBlockLocking( otherActiveUsers );
+	useBlockLocking( cursorState, otherActiveUsers );
 
 	useEffect( () => {
 		if ( collaborationMode === 'BLOCK-LEVEL-LOCKS' ) {

--- a/src/CollaborativeEditing.tsx
+++ b/src/CollaborativeEditing.tsx
@@ -5,6 +5,7 @@ import { useEffect } from '@wordpress/element';
 import { lockEditor, releaseEditor } from './utils';
 import { useCSSClassManager } from '@/hooks/useCSSClassManager';
 import { useGutenbergEditorControls } from '@/hooks/useGutenbergEditorControls';
+import { useBlockLocking } from './hooks/useBlockLocking';
 
 export const CollaborativeEditing = () => {
 	const { currentUserId, collaborationMode, state, syncAwareness } =
@@ -13,6 +14,7 @@ export const CollaborativeEditing = () => {
 
 	useCSSClassManager( collaborationMode, activeUsers, isLockHolder );
 	useGutenbergEditorControls( collaborationMode, isLockHolder );
+	useBlockLocking( otherActiveUsers );
 
 	useEffect( () => {
 		if ( collaborationMode === 'BLOCK-LEVEL-LOCKS' ) {

--- a/src/Persistence/AwarenessStateRepository.php
+++ b/src/Persistence/AwarenessStateRepository.php
@@ -27,11 +27,30 @@ class AwarenessStateRepository {
 			$awareness_state = [];
 		}
 
-		$ts                          = time();
+		$ts           = time();
+		$cursor_ts    = $ts;
+		$block_ts     = $ts;
+		$heartbeat_ts = $ts;
+
+		// are we updating the cursor state in the same block?
+		// if so, we need to preserve block_ts
+		if ( isset( $awareness_state[ $user_id ][ 'cursor_state' ] ) ) {
+			$existing_state = $awareness_state[ $user_id ][ 'cursor_state' ];
+			if (
+				isset( $existing_state[ 'blockIndex' ] ) &&
+				isset( $cursor_state[ 'blockIndex' ] ) &&
+				$cursor_state[ 'blockIndex' ] === $existing_state[ 'blockIndex' ] &&
+				isset( $awareness_state[ $user_id ][ 'block_ts' ] ) && $awareness_state[ $user_id ][ 'block_ts' ]
+			) {
+				$block_ts = $awareness_state[ $user_id ][ 'block_ts' ];
+			}
+		}
+
 		$awareness_state[ $user_id ] = [
 			'cursor_state' => $cursor_state,
-			'cursor_ts'    => $ts,
-			'heartbeat_ts' => $ts,
+			'cursor_ts'    => $cursor_ts,
+			'block_ts'     => $block_ts,
+			'heartbeat_ts' => $heartbeat_ts,
 			'color'        => $this->get_color( $user_id, $awareness_state ),
 		];
 		update_post_meta( $post_id, self::POSTMETA_KEY_AWARENESS, $awareness_state );

--- a/src/Persistence/AwarenessStateRepository.php
+++ b/src/Persistence/AwarenessStateRepository.php
@@ -2,10 +2,12 @@
 
 namespace DotOrg\GCE\Persistence;
 
+use DotOrg\GCE\Utils;
+
 class AwarenessStateRepository {
 
 	const POSTMETA_KEY_AWARENESS = 'gce_awareness';
-	const INACTIVITY_TIMEOUT = 240; // seconds
+	const INACTIVITY_TIMEOUT = 240000; // milliseconds
 	const COLORS = [
 		'#0073AA', // WordPress Blue - Primary accessible
 		'#008080', // Teal - Primary accessible
@@ -27,7 +29,7 @@ class AwarenessStateRepository {
 			$awareness_state = [];
 		}
 
-		$ts           = time();
+		$ts           = Utils::getTimestamp();
 		$cursor_ts    = $ts;
 		$block_ts     = $ts;
 		$heartbeat_ts = $ts;
@@ -83,7 +85,7 @@ class AwarenessStateRepository {
 	private function filter_inactive_users( array $awareness_state ) : array {
 		foreach ( $awareness_state as $user_id => $user_state ) {
 			$active_threshold = $user_state[ 'heartbeat_ts' ] + self::INACTIVITY_TIMEOUT;
-			if ( $active_threshold < time() ) {
+			if ( $active_threshold < Utils::getTimestamp() ) {
 				unset( $awareness_state[ $user_id ] );
 			}
 		}
@@ -126,7 +128,7 @@ class AwarenessStateRepository {
 		if ( ! isset( $awareness_state[ $user_id ] ) ) {
 			$awareness_state[ $user_id ] = [];
 		}
-		$awareness_state[ $user_id ][ 'heartbeat_ts' ] = time();
+		$awareness_state[ $user_id ][ 'heartbeat_ts' ] = Utils::getTimestamp();
 		update_post_meta( $post_id, self::POSTMETA_KEY_AWARENESS, $awareness_state );
 	}
 

--- a/src/Persistence/ContentRepository.php
+++ b/src/Persistence/ContentRepository.php
@@ -10,7 +10,7 @@ class ContentRepository {
 		$transient_key = "gce_sync_content_{$post_id}";
 		$sync_data = [
 			'content'     => [ 'html' => $content, 'title' => $title ],
-			'timestamp'   => microtime( true ),
+			'timestamp'   => Utils::getTimestamp(),
 			'post_id'     => $post_id,
 			'user_id'     => $user_id,
 			'fingerprint' => $fingerprint,

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -19,7 +19,7 @@ class Utils {
 	 * @return int
 	 */
 	public static function getTimestamp() {
-		$date = new DateTimeImmutable();
+		$date = new \DateTimeImmutable();
 		return (int) $date->format('Uv');
 	}
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -18,7 +18,7 @@ class Utils {
 	 * Return timestamp in milliseconds
 	 * @return int
 	 */
-	public static function getTimestamp() {
+	public static function getTimestamp() : int {
 		$date = new \DateTimeImmutable();
 		return (int) $date->format('Uv');
 	}

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -14,4 +14,13 @@ class Utils {
 		return $randomString;
 	}
 
+	/**
+	 * Return timestamp in milliseconds
+	 * @return int
+	 */
+	public static function getTimestamp() {
+		$date = new DateTimeImmutable();
+		return (int) $date->format('Uv');
+	}
+
 }

--- a/src/components/PresenceUI.tsx
+++ b/src/components/PresenceUI.tsx
@@ -2,7 +2,6 @@ import { createPortal } from '@wordpress/element';
 import { useMultiCursor } from '@/useMultiCursor';
 import AvatarList from './AvatarList';
 import { CursorState, AwarenessState } from '@/hooks/types';
-import { useBlockLocking } from '@/hooks/useBlockLocking';
 
 interface PresenceUIProps {
 	awarenessState: AwarenessState;
@@ -18,7 +17,6 @@ export const PresenceUI = ( {
 	const otherUsers = awarenessState;
 
 	useMultiCursor( currentUserId, otherUsers, syncAwareness );
-	useBlockLocking( otherUsers );
 
 	if ( ! otherUsers || Object.keys( otherUsers ).length === 0 ) {
 		return null;

--- a/src/components/PresenceUI.tsx
+++ b/src/components/PresenceUI.tsx
@@ -1,8 +1,8 @@
-import { createPortal, useEffect } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { createPortal } from '@wordpress/element';
 import { useMultiCursor } from '@/useMultiCursor';
 import AvatarList from './AvatarList';
 import { CursorState, AwarenessState } from '@/hooks/types';
+import { useBlockLocking } from '@/hooks/useBlockLocking';
 
 interface PresenceUIProps {
 	awarenessState: AwarenessState;
@@ -15,43 +15,10 @@ export const PresenceUI = ( {
 	syncAwareness,
 	currentUserId,
 }: PresenceUIProps ) => {
-	const { setLockedBlocks } = useDispatch( 'gce' );
-
 	const otherUsers = awarenessState;
 
 	useMultiCursor( currentUserId, otherUsers, syncAwareness );
-
-	// Assume user's cursors carries edit intent
-	// so lock all blocks where cursors of other users are at
-	useEffect( () => {
-		const lockedBlocks: string[] = [];
-		Object.values( otherUsers ).forEach( ( user ) => {
-			if ( ! user.cursor_state ) {
-				// eslint-disable-next-line no-console
-				console.log( '🚧 when is this happening?', user );
-				return;
-			}
-			const blockIndex =
-				'blockIndex' in user.cursor_state
-					? user.cursor_state.blockIndex
-					: user.cursor_state.blockIndexStart;
-
-			const existingBlocks = wp.data
-				.select( 'core/block-editor' )
-				.getBlocks();
-
-			const block = existingBlocks[ blockIndex ];
-			if ( block ) {
-				lockedBlocks.push( block.clientId );
-			}
-		} );
-		setLockedBlocks( lockedBlocks );
-
-		// Cleanup function to remove locks when users leave
-		return () => {
-			setLockedBlocks( [] );
-		};
-	}, [ otherUsers, setLockedBlocks ] );
+	useBlockLocking( otherUsers );
 
 	if ( ! otherUsers || Object.keys( otherUsers ).length === 0 ) {
 		return null;

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -27,15 +27,18 @@ export interface MultiBlockSelectionCursorState {
 }
 
 export interface User {
-	id: number;
+	id: UserId;
 	name: string;
 	slug: string;
 	avatar: string;
 }
 
+export type UserId = number;
+
 export interface UserAwareness {
 	cursor_state: CursorState;
-	cursor_ts: number;
+	cursor_ts: number; // timestamp for cursor state
+	block_ts: number; // timestamp for when the current block was engaged
 	heartbeat_ts: number;
 	user_data: User;
 	color: string;

--- a/src/hooks/useBlockLocking.ts
+++ b/src/hooks/useBlockLocking.ts
@@ -1,0 +1,37 @@
+import { useEffect } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { AwarenessState } from '@/hooks/types';
+
+export const useBlockLocking = ( otherUsers: AwarenessState ) => {
+	const { setLockedBlocks } = useDispatch( 'gce' );
+
+	useEffect( () => {
+		const lockedBlocks: string[] = [];
+		Object.values( otherUsers ).forEach( ( user ) => {
+			if ( ! user.cursor_state ) {
+				// eslint-disable-next-line no-console
+				console.log( '🚧 when is this happening?', user );
+				return;
+			}
+			const blockIndex =
+				'blockIndex' in user.cursor_state
+					? user.cursor_state.blockIndex
+					: user.cursor_state.blockIndexStart;
+
+			const existingBlocks = wp.data
+				.select( 'core/block-editor' )
+				.getBlocks();
+
+			const block = existingBlocks[ blockIndex ];
+			if ( block ) {
+				lockedBlocks.push( block.clientId );
+			}
+		} );
+		setLockedBlocks( lockedBlocks );
+
+		// Cleanup function to remove locks when users leave
+		return () => {
+			setLockedBlocks( [] );
+		};
+	}, [ otherUsers, setLockedBlocks ] );
+};

--- a/src/hooks/useBlockLocking.ts
+++ b/src/hooks/useBlockLocking.ts
@@ -37,22 +37,20 @@ export const useBlockLocking = (
 			}
 
 			if ( 'blockIndex' in user.cursor_state ) {
+				const blockIndex = user.cursor_state.blockIndex;
 				if (
 					trackedCurrentUser &&
 					'blockIndex' in trackedCurrentUser &&
-					trackedCurrentUser.blockIndex ===
-						user.cursor_state.blockIndex
+					trackedCurrentUser.blockIndex === blockIndex
 				) {
 					// which one has the older timestamp?
-					if ( user.cursor_ts < trackedCurrentUser.blockTs ) {
-						targetBlocks[ user.cursor_state.blockIndex ] =
-							user.user_data.id;
+					if ( user.block_ts < trackedCurrentUser.blockTs ) {
+						targetBlocks[ blockIndex ] = user.user_data.id;
 					}
 					// if the current user is the one who has the older timestamp,
 					// we do not need locks for ourselves, so do nothing
 				} else {
-					targetBlocks[ user.cursor_state.blockIndex ] =
-						user.user_data.id;
+					targetBlocks[ blockIndex ] = user.user_data.id;
 				}
 			}
 		} );

--- a/src/hooks/useBlockLocking.ts
+++ b/src/hooks/useBlockLocking.ts
@@ -1,37 +1,76 @@
 import { useEffect } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
-import { AwarenessState } from '@/hooks/types';
+import { AwarenessState, CursorState, UserId } from '@/hooks/types';
+import { useTrackedCurrentUser } from './useTrackedCurrentUser';
 
-export const useBlockLocking = ( otherUsers: AwarenessState ) => {
+export const useBlockLocking = (
+	currentUser: CursorState | null,
+	otherUsers: AwarenessState
+) => {
 	const { setLockedBlocks } = useDispatch( 'gce' );
 
+	const trackedCurrentUser = useTrackedCurrentUser( currentUser );
+
 	useEffect( () => {
+		// target blocks which are locked by other users
+		const targetBlocks: {
+			[ blockIndex: string ]: UserId; // we currently don't use the userId,
+			// but it's here for future use for cases where we want to highlight the user who locked the block
+		} = {};
+
 		const lockedBlocks: string[] = [];
-		Object.values( otherUsers ).forEach( ( user ) => {
+		Object.entries( otherUsers ).forEach( ( [ , user ] ) => {
 			if ( ! user.cursor_state ) {
+				// eslint-disable-next-line no-alert
+				alert(
+					'🚧 found user in awareness state without cursor state,' +
+						'check console'
+				);
 				// eslint-disable-next-line no-console
-				console.log( '🚧 when is this happening?', user );
+				console.log(
+					'🚧 found user in awareness state without cursor state:',
+					user
+				);
 				return;
 			}
-			const blockIndex =
-				'blockIndex' in user.cursor_state
-					? user.cursor_state.blockIndex
-					: user.cursor_state.blockIndexStart;
 
-			const existingBlocks = wp.data
-				.select( 'core/block-editor' )
-				.getBlocks();
+			if ( 'blockIndex' in user.cursor_state ) {
+				if (
+					trackedCurrentUser &&
+					'blockIndex' in trackedCurrentUser &&
+					trackedCurrentUser.blockIndex ===
+						user.cursor_state.blockIndex
+				) {
+					// which one has the older timestamp?
+					if ( user.cursor_ts < trackedCurrentUser.blockTs ) {
+						targetBlocks[ user.cursor_state.blockIndex ] =
+							user.user_data.id;
+					}
+					// if the current user is the one who has the older timestamp,
+					// we do not need locks for ourselves, so do nothing
+				} else {
+					targetBlocks[ user.cursor_state.blockIndex ] =
+						user.user_data.id;
+				}
+			}
+		} );
 
+		const existingBlocks = wp.data
+			.select( 'core/block-editor' )
+			.getBlocks();
+
+		Object.entries( targetBlocks ).forEach( ( [ blockIndex ] ) => {
 			const block = existingBlocks[ blockIndex ];
 			if ( block ) {
 				lockedBlocks.push( block.clientId );
 			}
 		} );
+
 		setLockedBlocks( lockedBlocks );
 
 		// Cleanup function to remove locks when users leave
 		return () => {
 			setLockedBlocks( [] );
 		};
-	}, [ otherUsers, setLockedBlocks ] );
+	}, [ otherUsers, setLockedBlocks, trackedCurrentUser ] );
 };

--- a/src/hooks/useBlockLocking.ts
+++ b/src/hooks/useBlockLocking.ts
@@ -2,10 +2,12 @@ import { useEffect } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { AwarenessState, CursorState, UserId } from '@/hooks/types';
 import { useTrackedCurrentUser } from './useTrackedCurrentUser';
+import { BlockInstance } from '@wordpress/blocks';
 
 export const useBlockLocking = (
 	currentUser: CursorState | null,
-	otherUsers: AwarenessState
+	otherUsers: AwarenessState,
+	blocks: BlockInstance[]
 ) => {
 	const { setLockedBlocks } = useDispatch( 'gce' );
 
@@ -14,7 +16,7 @@ export const useBlockLocking = (
 	useEffect( () => {
 		// target blocks which are locked by other users
 		const targetBlocks: {
-			[ blockIndex: string ]: UserId; // we currently don't use the userId,
+			[ blockIndex: number ]: UserId; // we currently don't use the userId,
 			// but it's here for future use for cases where we want to highlight the user who locked the block
 		} = {};
 
@@ -55,12 +57,8 @@ export const useBlockLocking = (
 			}
 		} );
 
-		const existingBlocks = wp.data
-			.select( 'core/block-editor' )
-			.getBlocks();
-
 		Object.entries( targetBlocks ).forEach( ( [ blockIndex ] ) => {
-			const block = existingBlocks[ blockIndex ];
+			const block = blocks[ Number( blockIndex ) ];
 			if ( block ) {
 				lockedBlocks.push( block.clientId );
 			}
@@ -72,5 +70,5 @@ export const useBlockLocking = (
 		return () => {
 			setLockedBlocks( [] );
 		};
-	}, [ otherUsers, setLockedBlocks, trackedCurrentUser ] );
+	}, [ trackedCurrentUser, otherUsers, blocks, setLockedBlocks ] );
 };

--- a/src/hooks/useDataManager.ts
+++ b/src/hooks/useDataManager.ts
@@ -347,6 +347,7 @@ export const useDataManager = ( transport = 'ajax-with-long-polling' ) => {
 
 	return {
 		currentUserId,
+		cursorState,
 		collaborationMode,
 		state: { ...state, ...derivedState },
 		syncAwareness,

--- a/src/hooks/useDataManager.ts
+++ b/src/hooks/useDataManager.ts
@@ -19,6 +19,7 @@ import { CursorState, AwarenessState } from './types';
 import { TransportReceivedData, ContentSyncPayload } from '@/transports/types';
 import { useProactiveStalenessCheck } from './useProactiveStalenessCheck';
 import { BlockChangeTracker, Block } from '@/block-sync';
+import { isEqual } from 'lodash';
 
 const restoreSelection = (
 	state: CursorState | null,
@@ -240,6 +241,7 @@ export const useDataManager = ( transport = 'ajax-with-long-polling' ) => {
 	const { resetBlocks, resetSelection } = useDispatch( 'core/block-editor' );
 	const [ recalcTrigger, forceRecalculate ] = useReducer( ( x ) => x + 1, 0 );
 	const tracker = useRef( new BlockChangeTracker() );
+	const derivedStateRef = useRef< Partial< DataManagerState > >( {} );
 
 	const onDataReceived = useCallback(
 		( data: TransportReceivedData ) => {
@@ -319,18 +321,24 @@ export const useDataManager = ( transport = 'ajax-with-long-polling' ) => {
 			delete otherActiveUsers[ currentUserId ];
 		}
 
-		return {
+		const newDerivedState = {
 			awareness,
 			activeUsers,
 			otherUsers,
 			otherActiveUsers,
 		};
+
+		if ( isEqual( derivedStateRef.current, newDerivedState ) ) {
+			return derivedStateRef.current;
+		}
+		derivedStateRef.current = newDerivedState;
+		return newDerivedState;
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ awareness, currentUserId, recalcTrigger ] );
 
 	// Proactively check for stale users and trigger a state recalculation.
 	useProactiveStalenessCheck(
-		derivedState.otherActiveUsers,
+		derivedState.otherActiveUsers ?? {},
 		forceRecalculate
 	);
 
@@ -348,6 +356,7 @@ export const useDataManager = ( transport = 'ajax-with-long-polling' ) => {
 		currentUserId,
 		cursorState,
 		collaborationMode,
+		blocks,
 		state: { ...state, ...derivedState },
 		syncAwareness,
 	};

--- a/src/hooks/useDataManager.ts
+++ b/src/hooks/useDataManager.ts
@@ -300,8 +300,7 @@ export const useDataManager = ( transport = 'ajax-with-long-polling' ) => {
 			( acc, key ) => {
 				const userId = Number( key );
 				const userData = awareness[ userId ];
-				const heartbeatAge =
-					Math.floor( Date.now() / 1000 ) - userData.heartbeat_ts;
+				const heartbeatAge = Date.now() - userData.heartbeat_ts;
 				if ( heartbeatAge < window.gce.awarenessTimeout ) {
 					acc[ userId ] = userData;
 				}

--- a/src/hooks/useTrackedCurrentUser.ts
+++ b/src/hooks/useTrackedCurrentUser.ts
@@ -1,0 +1,32 @@
+import { useState, useRef, useEffect, useMemo } from '@wordpress/element';
+import { CursorState } from './types';
+
+const getBlockIndex = ( state: CursorState | null ): number | undefined => {
+	if ( ! state ) {
+		return undefined;
+	}
+
+	// For locks, we only care for blockIndex and not blockIndexStart
+	return 'blockIndex' in state ? state.blockIndex : undefined;
+};
+
+export const useTrackedCurrentUser = ( currentUser: CursorState | null ) => {
+	const [ blockTs, setBlockTs ] = useState< number >( 0 );
+	const prevBlockIndexRef = useRef< number | undefined >();
+
+	useEffect( () => {
+		const currentBlockIndex = getBlockIndex( currentUser );
+
+		if ( prevBlockIndexRef.current !== currentBlockIndex ) {
+			setBlockTs( Date.now() );
+		}
+		prevBlockIndexRef.current = currentBlockIndex;
+	}, [ currentUser ] );
+
+	return useMemo( () => {
+		if ( ! currentUser ) {
+			return null;
+		}
+		return { ...currentUser, blockTs };
+	}, [ currentUser, blockTs ] );
+};


### PR DESCRIPTION
This PR improves the locking in following ways:

- Refactored to control locking at top level
- Track timestamp of block engagement instead of timestamp of cursor state
- Everything in milliseconds as integers

fixes #24 